### PR TITLE
Making assert equals checking strict

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -89,12 +89,12 @@ final class ClientTest extends BaseTest
             $request->hasHeader('Content-Type')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $request->getHeader('Accept')[0],
             'application/json'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $request->getHeader('Content-Type')[0],
             'application/json'
         );

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -74,7 +74,7 @@ final class ResourceTest extends BaseTest
         $this->isJson($response->__toString());
 
         // Can get data
-        $this->assertEquals(1, $response->id);
+        $this->assertSame(1, $response->id);
         $this->assertFalse($response->notExistingProperty);
         $this->assertTrue(isset($response->id));
     }
@@ -154,8 +154,8 @@ final class ResourceTest extends BaseTest
         $this->assertInstanceOf(ItemResponse::class, $response);
 
         $error =$response->getError();
-        $this->assertEquals('DataConflictException', $error->exceptionType);
+        $this->assertSame('DataConflictException', $error->exceptionType);
         $this->assertObjectHasAttribute('messages', $error->exception);
-        $this->assertEquals('Item not Found', $error->exception->messages[0]->messageCode);
+        $this->assertSame('Item not Found', $error->exception->messages[0]->messageCode);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assert equals checking strict.